### PR TITLE
Torchvision transforms improvements

### DIFF
--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -229,16 +229,16 @@ class AnomalibDataModule(LightningDataModule, ABC):
         return self.test_dataloader()
 
     @property
-    def user_transform(self) -> Transform:
-        """This property returns the user-specified transform, if any.
+    def transform(self) -> Transform:
+        """Property that returns the transform.
 
         This property is accessed by the engine to set the transform for the model. The eval_transform takes precedence
         over the train_transform, because the transform that we store in the model is the one that should be used during
         inference.
         """
-        if self._eval_transform:
-            return self._eval_transform
-        if self._train_transform:
+        if self.eval_transform:
+            return self.eval_transform
+        if self.train_transform:
             return self.train_transform
         return None
 

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -250,7 +250,7 @@ class AnomalibDataModule(LightningDataModule, ABC):
         """
         if self._train_transform:
             return self._train_transform
-        if self.trainer and self.trainer.model:
+        if hasattr(self, "trainer") and self.trainer.model:
             return self.trainer.model.transform
         return None
 
@@ -262,6 +262,6 @@ class AnomalibDataModule(LightningDataModule, ABC):
         """
         if self._eval_transform:
             return self._eval_transform
-        if self.trainer and self.trainer.model:
+        if hasattr(self, "trainer") and self.trainer.model:
             return self.trainer.model.transform
         return None

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -229,19 +229,39 @@ class AnomalibDataModule(LightningDataModule, ABC):
         return self.test_dataloader()
 
     @property
+    def user_transform(self) -> Transform:
+        """This property returns the user-specified transform, if any.
+
+        This property is accessed by the engine to set the transform for the model. The eval_transform takes precedence
+        over the train_transform, because the transform that we store in the model is the one that should be used during
+        inference.
+        """
+        if self._eval_transform:
+            return self._eval_transform
+        if self._train_transform:
+            return self.train_transform
+        return None
+
+    @property
     def train_transform(self) -> Transform:
-        """Get the transform that the model should use during training."""
+        """Get the transforms that the datamodule should apply during training.
+
+        If the train_transform is not set, the engine will request the transform from the model.
+        """
         if self._train_transform:
             return self._train_transform
         if self.trainer and self.trainer.model:
-            return self.trainer.model.configure_transforms(self.image_size)
+            return self.trainer.model.transform
         return None
 
     @property
     def eval_transform(self) -> Transform:
-        """Get the transform that the model should use during inference."""
+        """Get the transform that the datamodule should apply during inference.
+
+        If the eval_transform is not set, the engine will request the transform from the model.
+        """
         if self._eval_transform:
             return self._eval_transform
         if self.trainer and self.trainer.model:
-            return self.trainer.model.configure_transforms(self.image_size)
+            return self.trainer.model.transform
         return None

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -250,7 +250,7 @@ class AnomalibDataModule(LightningDataModule, ABC):
         """
         if self._train_transform:
             return self._train_transform
-        if hasattr(self, "trainer") and self.trainer.model:
+        if getattr(self, "trainer", None) and self.trainer.model:
             return self.trainer.model.transform
         return None
 
@@ -262,6 +262,6 @@ class AnomalibDataModule(LightningDataModule, ABC):
         """
         if self._eval_transform:
             return self._eval_transform
-        if hasattr(self, "trainer") and self.trainer.model:
+        if getattr(self, "trainer", None) and self.trainer.model:
             return self.trainer.model.transform
         return None

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -101,8 +101,8 @@ class AnomalibDataModule(LightningDataModule, ABC):
         self.seed = seed
 
         # set transforms
-        self.train_transform = train_transform or transform
-        self.eval_transform = eval_transform or transform
+        self._train_transform = train_transform or transform
+        self._eval_transform = eval_transform or transform
 
         self.train_data: AnomalibDataset
         self.val_data: AnomalibDataset
@@ -227,3 +227,21 @@ class AnomalibDataModule(LightningDataModule, ABC):
     def predict_dataloader(self) -> EVAL_DATALOADERS:
         """Use the test dataloader for inference unless overridden."""
         return self.test_dataloader()
+
+    @property
+    def train_transform(self) -> Transform:
+        """Get the transform that the model should use during training."""
+        if self._train_transform:
+            return self._train_transform
+        if self.trainer and self.trainer.model:
+            return self.trainer.model.configure_transforms(self.image_size)
+        return None
+
+    @property
+    def eval_transform(self) -> Transform:
+        """Get the transform that the model should use during inference."""
+        if self._eval_transform:
+            return self._eval_transform
+        if self.trainer and self.trainer.model:
+            return self.trainer.model.transform
+        return None

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -243,5 +243,5 @@ class AnomalibDataModule(LightningDataModule, ABC):
         if self._eval_transform:
             return self._eval_transform
         if self.trainer and self.trainer.model:
-            return self.trainer.model.transform
+            return self.trainer.model.configure_transforms(self.image_size)
         return None

--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -433,7 +433,7 @@ class Engine:
         """
         self._setup_trainer(model)
         self._setup_dataset_task(train_dataloaders, val_dataloaders, datamodule)
-        self._setup_transform(model, datamodule, ckpt_path)
+        self._setup_transform(model, datamodule=datamodule, ckpt_path=ckpt_path)
         if model.learning_type in [LearningType.ZERO_SHOT, LearningType.FEW_SHOT]:
             # if the model is zero-shot or few-shot, we only need to run validate for normalization and thresholding
             self.trainer.validate(model, val_dataloaders, datamodule=datamodule, ckpt_path=ckpt_path)
@@ -485,7 +485,7 @@ class Engine:
         if model:
             self._setup_trainer(model)
         self._setup_dataset_task(dataloaders)
-        self._setup_transform(model or self.model, datamodule, ckpt_path)
+        self._setup_transform(model or self.model, datamodule=datamodule, ckpt_path=ckpt_path)
         return self.trainer.validate(model, dataloaders, ckpt_path, verbose, datamodule)
 
     def test(
@@ -573,7 +573,7 @@ class Engine:
             msg = "`Engine.test()` requires an `AnomalyModule` when it hasn't been passed in a previous run."
             raise RuntimeError(msg)
         self._setup_dataset_task(dataloaders)
-        self._setup_transform(model or self.model, datamodule, ckpt_path)
+        self._setup_transform(model or self.model, datamodule=datamodule, ckpt_path=ckpt_path)
         if self._should_run_validation(model or self.model, dataloaders, datamodule, ckpt_path):
             logger.info("Running validation before testing to collect normalization metrics and/or thresholds.")
             self.trainer.validate(model, dataloaders, None, verbose=False, datamodule=datamodule)
@@ -665,7 +665,7 @@ class Engine:
                 raise TypeError(msg)
 
         self._setup_dataset_task(dataloaders, datamodule)
-        self._setup_transform(model or self.model, datamodule, ckpt_path)
+        self._setup_transform(model or self.model, datamodule=datamodule, ckpt_path=ckpt_path)
 
         if self._should_run_validation(model or self.model, None, datamodule, ckpt_path):
             logger.info("Running validation before predicting to collect normalization metrics and/or thresholds.")
@@ -725,7 +725,7 @@ class Engine:
             test_dataloaders,
             datamodule,
         )
-        self._setup_transform(model, datamodule, ckpt_path)
+        self._setup_transform(model, datamodule=datamodule, ckpt_path=ckpt_path)
         if model.learning_type in [LearningType.ZERO_SHOT, LearningType.FEW_SHOT]:
             # if the model is zero-shot or few-shot, we only need to run validate for normalization and thresholding
             self.trainer.validate(model, val_dataloaders, None, verbose=False, datamodule=datamodule)

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -205,11 +205,7 @@ class AnomalyModule(pl.LightningModule, ABC):
         If a transform has been set using `set_transform`, it will be returned. Otherwise, we will use the
         model-specific default transform, conditioned on the input size.
         """
-        if self._transform is not None:
-            return self._transform
-        if self._trainer and self.trainer.datamodule:
-            return self.configure_transforms(self.trainer.datamodule.image_size)
-        return self.configure_transforms()
+        return self._transform
 
     def set_transform(self, transform: Transform) -> None:
         """Update the transform linked to the model instance."""

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -246,11 +246,8 @@ class AnomalyModule(pl.LightningModule, ABC):
 
     def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         """Save the transform and input size to the checkpoint."""
-        torch.save(self.transform, "transform.pt")
         checkpoint["input_size"] = self.input_size
-        return super().on_save_checkpoint(checkpoint)
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         """Load the transform and input size from the checkpoint."""
-        self._transform = torch.load("transform.pt")
         self._setup(input_size=checkpoint["input_size"])

--- a/src/anomalib/models/components/base/memory_bank_module.py
+++ b/src/anomalib/models/components/base/memory_bank_module.py
@@ -36,3 +36,9 @@ class MemoryBankMixin(nn.Module):
         if not self._is_fitted:
             self.fit()
             self._is_fitted = torch.tensor([True])
+
+    def on_train_epoch_end(self) -> None:
+        """Ensure that the model is fitted before validation starts."""
+        if not self._is_fitted:
+            self.fit()
+            self._is_fitted = torch.tensor([True])

--- a/src/anomalib/models/image/padim/lightning_model.py
+++ b/src/anomalib/models/image/padim/lightning_model.py
@@ -58,13 +58,15 @@ class Padim(MemoryBankMixin, AnomalyModule):
         self.stats: list[torch.Tensor] = []
         self.embeddings: list[torch.Tensor] = []
 
-    def _setup(self, input_size: tuple[int, int] | None = None) -> None:
-        """Setup the model and the loss function."""
-        input_size = input_size or self.input_size
-        assert input_size is not None, "Input size must be specified."
+    def _setup(self) -> None:
+        """Create the model.
+
+        The model is created at setup time to ensure that the right input size is used.
+        """
+        assert self.input_size is not None, "Padim model needs input size to build torch model."
         self.model: PadimModel = PadimModel(
             backbone=self.backbone,
-            input_size=input_size or self.input_size,
+            input_size=self.input_size,
             pre_trained=self.pre_trained,
             layers=self.layers,
             n_features=self.n_features,

--- a/src/anomalib/models/image/padim/lightning_model.py
+++ b/src/anomalib/models/image/padim/lightning_model.py
@@ -58,13 +58,15 @@ class Padim(MemoryBankMixin, AnomalyModule):
         self.stats: list[torch.Tensor] = []
         self.embeddings: list[torch.Tensor] = []
 
+        self.model: PadimModel
+
     def _setup(self) -> None:
         """Create the model.
 
         The model is created at setup time to ensure that the right input size is used.
         """
         assert self.input_size is not None, "Padim model needs input size to build torch model."
-        self.model: PadimModel = PadimModel(
+        self.model = PadimModel(
             backbone=self.backbone,
             input_size=self.input_size,
             pre_trained=self.pre_trained,

--- a/tests/unit/engine/test_setup_transform.py
+++ b/tests/unit/engine/test_setup_transform.py
@@ -3,6 +3,11 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
 import torch
 from torch.utils.data import DataLoader
 from torchvision.transforms.v2 import Resize, Transform
@@ -21,12 +26,6 @@ class DummyDataset(AnomalibDataset):
         self.image = torch.rand(3, 10, 10)
         self._samples = None
 
-    def __getitem__(self, index: int) -> torch.Tensor:
-        """Return the image tensor."""
-        if self.transform:
-            return self.transform(self.image)
-        return self.image
-
     def _setup(self, _stage: str | None = None) -> None:
         self._samples = None
 
@@ -41,10 +40,6 @@ class DummyModel(AnomalyModule):
     def __init__(self) -> None:
         super().__init__()
         self.model = torch.nn.Linear(10, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Return the input tensor."""
-        return self.model(x)
 
     def configure_transforms(self, image_size: tuple[int, int] | None = None) -> Transform:
         """Return a Resize transform."""
@@ -95,102 +90,132 @@ class DummyDataModule(AnomalibDataModule):
         self.test_data = DummyDataset(transform=self.eval_transform)
 
 
+@pytest.fixture()
+def checkpoint_path() -> Generator:
+    """Fixture to create a temporary checkpoint file that stores a Resize transform."""
+    # Create a temporary file
+    transform = Resize((50, 50))
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "model.ckpt"
+        checkpoint = {"transform": transform}
+        torch.save(checkpoint, file_path)
+
+        yield file_path
+
+
 class TestSetupTransform:
     """Tests for the `_setup_transform` method of the Anomalib Engine."""
 
     # test update single dataloader
     def test_single_dataloader_default_transform(self) -> None:
         """Tests if the default model transform is used when no transform is passed to the dataloader."""
-        engine = Engine()
         dataset = DummyDataset()
         dataloader = DataLoader(dataset, batch_size=1)
         model = DummyModel()
         # before the setup_transform is called, the dataset should not have a transform
         assert dataset.transform is None
-        engine._setup_transform(model, dataloaders=dataloader)  # noqa: SLF001
+        Engine._setup_transform(model, dataloaders=dataloader)  # noqa: SLF001
         # after the setup_transform is called, the dataset should have the default transform from the model
         assert dataset.transform is not None
 
     # test update multiple dataloaders
     def test_multiple_dataloaders_default_transform(self) -> None:
         """Tests if the default model transform is used when no transform is passed to the dataloader."""
-        engine = Engine()
         dataset = DummyDataset()
         dataloader = DataLoader(dataset, batch_size=1)
         model = DummyModel()
         # before the setup_transform is called, the dataset should not have a transform
         assert dataset.transform is None
-        engine._setup_transform(model, dataloaders=[dataloader, dataloader])  # noqa: SLF001
+        Engine._setup_transform(model, dataloaders=[dataloader, dataloader])  # noqa: SLF001
         # after the setup_transform is called, the dataset should have the default transform from the model
         assert dataset.transform is not None
+
+    def test_single_dataloader_user_specified_transform(self) -> None:
+        """Tests if the user-specified transform is used when passed to the dataloader."""
+        transform = Transform()
+        dataset = DummyDataset(transform=transform)
+        dataloader = DataLoader(dataset, batch_size=1)
+        model = DummyModel()
+        # before the setup_transform is called, the dataset should have the custom transform
+        assert dataset.transform == transform
+        Engine._setup_transform(model, dataloaders=dataloader)  # noqa: SLF001
+        # after the setup_transform is called, the model should have the custom transform
+        assert model.transform == transform
 
     # test if the user-specified transform is used when passed to the datamodule
     def test_user_specified_transform(self) -> None:
         """Tests if the user-specified transform is used when passed to the datamodule."""
-        custom_transform = Resize((100, 100))
-        engine = Engine()
+        custom_transform = Transform()
         datamodule = DummyDataModule(transform=custom_transform)
         model = DummyModel()
         # assert that the datamodule uses the custom transform before and after setup_transform is called
         assert datamodule.train_transform == custom_transform
         assert datamodule.eval_transform == custom_transform
-        engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
+        Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
         assert datamodule.train_transform == custom_transform
         assert datamodule.eval_transform == custom_transform
+        assert model.transform == custom_transform
 
     # test if the user-specified transform is used when passed to the datamodule
     def test_user_specified_train_transform(self) -> None:
         """Tests if the user-specified transform is used when passed to the datamodule as train_transform."""
         model = DummyModel()
-        default_size = model.configure_transforms().size
-        custom_transform = Resize((100, 100))
-        engine = Engine()
+        custom_transform = Transform()
         datamodule = DummyDataModule(train_transform=custom_transform)
         # before calling setup, train_transform should be the custom transform and eval_transform should be None
         assert datamodule.train_transform == custom_transform
         assert datamodule.eval_transform is None
-        engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
+        Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
         # after calling setup, train_transform should be the custom transform and eval_transform should be the default
         assert datamodule.train_transform == custom_transform
-        assert isinstance(datamodule.eval_transform, Resize)
-        assert datamodule.eval_transform.size == default_size
+        assert datamodule.eval_transform is None
+        assert model.transform == custom_transform
+
+    # test if the user-specified transform is used when passed to the datamodule
+    def test_user_specified_eval_transform(self) -> None:
+        """Tests if the user-specified transform is used when passed to the datamodule as eval_transform."""
+        model = DummyModel()
+        custom_transform = Transform()
+        datamodule = DummyDataModule(eval_transform=custom_transform)
+        # before calling setup, train_transform should be the custom transform and eval_transform should be None
+        assert datamodule.train_transform is None
+        assert datamodule.eval_transform == custom_transform
+        Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
+        # after calling setup, train_transform should be the custom transform and eval_transform should be the default
+        assert datamodule.train_transform is None
+        assert datamodule.eval_transform == custom_transform
+        assert model.transform == custom_transform
 
     # test update datamodule
     def test_datamodule_default_transform(self) -> None:
         """Tests if the default model transform is used when no transform is passed to the datamodule."""
-        engine = Engine()
         datamodule = DummyDataModule()
         model = DummyModel()
         # assert that the datamodule has a transform after the setup_transform is called
-        assert datamodule.train_transform is None
-        assert datamodule.eval_transform is None
-        engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
-        assert datamodule.train_transform is not None
-        assert datamodule.eval_transform is not None
+        Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
+        assert isinstance(model.transform, Transform)
 
     # test if image size is taken from datamodule
     def test_datamodule_image_size(self) -> None:
         """Tests if the image size that is passed to the datamodule overwrites the default size from the model."""
-        engine = Engine()
         datamodule = DummyDataModule(image_size=(100, 100))
         model = DummyModel()
         # assert that the datamodule has a transform after the setup_transform is called
-        assert datamodule.train_transform is None
-        assert datamodule.eval_transform is None
-        engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
-        assert isinstance(datamodule.train_transform, Resize)
-        assert isinstance(datamodule.eval_transform, Resize)
-        assert datamodule.train_transform.size == [100, 100]
-        assert datamodule.eval_transform.size == [100, 100]
+        Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
+        assert isinstance(model.transform, Resize)
+        assert model.transform.size == [100, 100]
 
-    # test if the updated transform is used in the dataloader
-    def test_datamodule_dataloader(self) -> None:
-        """Tests if batch returned by the dataloader has the correct shape after the setup_transform is called."""
-        engine = Engine()
-        datamodule = DummyDataModule()
+    def test_transform_from_checkpoint(self, checkpoint_path: Path) -> None:
+        """Tests if the transform from the checkpoint is used."""
         model = DummyModel()
-        engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
-        datamodule.setup()
-        dataloader = datamodule.train_dataloader()
-        for batch in dataloader:
-            assert batch.shape == (1, 3, 256, 256)
+        Engine._setup_transform(model, ckpt_path=checkpoint_path)  # noqa: SLF001
+        assert isinstance(model.transform, Resize)
+        assert model.transform.size == [50, 50]
+
+    def test_precendence_datamodule(self, checkpoint_path: Path) -> None:
+        """Tests if transform from the datamodule goes first if both checkpoint and datamodule are provided."""
+        transform = Transform()
+        datamodule = DummyDataModule(transform=transform)
+        model = DummyModel()
+        Engine._setup_transform(model, ckpt_path=checkpoint_path, datamodule=datamodule)  # noqa: SLF001
+        assert model.transform == transform

--- a/tests/unit/engine/test_setup_transform.py
+++ b/tests/unit/engine/test_setup_transform.py
@@ -130,7 +130,7 @@ class TestSetupTransform:
         # after the setup_transform is called, the dataset should have the default transform from the model
         assert dataset.transform is not None
 
-    def test_single_dataloader_user_specified_transform(self) -> None:
+    def test_single_dataloader_custom_transform(self) -> None:
         """Tests if the user-specified transform is used when passed to the dataloader."""
         transform = Transform()
         dataset = DummyDataset(transform=transform)
@@ -143,48 +143,48 @@ class TestSetupTransform:
         assert model.transform == transform
 
     # test if the user-specified transform is used when passed to the datamodule
-    def test_user_specified_transform(self) -> None:
+    def test_custom_transform(self) -> None:
         """Tests if the user-specified transform is used when passed to the datamodule."""
-        custom_transform = Transform()
-        datamodule = DummyDataModule(transform=custom_transform)
+        transform = Transform()
+        datamodule = DummyDataModule(transform=transform)
         model = DummyModel()
         # assert that the datamodule uses the custom transform before and after setup_transform is called
-        assert datamodule.train_transform == custom_transform
-        assert datamodule.eval_transform == custom_transform
+        assert datamodule.train_transform == transform
+        assert datamodule.eval_transform == transform
         Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
-        assert datamodule.train_transform == custom_transform
-        assert datamodule.eval_transform == custom_transform
-        assert model.transform == custom_transform
+        assert datamodule.train_transform == transform
+        assert datamodule.eval_transform == transform
+        assert model.transform == transform
 
     # test if the user-specified transform is used when passed to the datamodule
-    def test_user_specified_train_transform(self) -> None:
+    def test_custom_train_transform(self) -> None:
         """Tests if the user-specified transform is used when passed to the datamodule as train_transform."""
         model = DummyModel()
-        custom_transform = Transform()
-        datamodule = DummyDataModule(train_transform=custom_transform)
+        transform = Transform()
+        datamodule = DummyDataModule(train_transform=transform)
         # before calling setup, train_transform should be the custom transform and eval_transform should be None
-        assert datamodule.train_transform == custom_transform
+        assert datamodule.train_transform == transform
         assert datamodule.eval_transform is None
         Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
         # after calling setup, train_transform should be the custom transform and eval_transform should be the default
-        assert datamodule.train_transform == custom_transform
+        assert datamodule.train_transform == transform
         assert datamodule.eval_transform is None
-        assert model.transform == custom_transform
+        assert model.transform == transform
 
     # test if the user-specified transform is used when passed to the datamodule
-    def test_user_specified_eval_transform(self) -> None:
+    def test_custom_eval_transform(self) -> None:
         """Tests if the user-specified transform is used when passed to the datamodule as eval_transform."""
         model = DummyModel()
-        custom_transform = Transform()
-        datamodule = DummyDataModule(eval_transform=custom_transform)
+        transform = Transform()
+        datamodule = DummyDataModule(eval_transform=transform)
         # before calling setup, train_transform should be the custom transform and eval_transform should be None
         assert datamodule.train_transform is None
-        assert datamodule.eval_transform == custom_transform
+        assert datamodule.eval_transform == transform
         Engine._setup_transform(model, datamodule=datamodule)  # noqa: SLF001
         # after calling setup, train_transform should be the custom transform and eval_transform should be the default
         assert datamodule.train_transform is None
-        assert datamodule.eval_transform == custom_transform
-        assert model.transform == custom_transform
+        assert datamodule.eval_transform == transform
+        assert model.transform == transform
 
     # test update datamodule
     def test_datamodule_default_transform(self) -> None:

--- a/tests/unit/models/test_model_utils.py
+++ b/tests/unit/models/test_model_utils.py
@@ -29,7 +29,7 @@ class TestGetModel:
 
     def test_get_model_by_name_with_init_args(self) -> None:
         """Test get_model by name with init args."""
-        model = get_model("Patchcore", input_size=(100, 100))
+        model = get_model("Patchcore", backbone="wide_resnet50_2")
         assert isinstance(model, Patchcore)
 
     def test_get_model_by_dict(self) -> None:
@@ -39,14 +39,14 @@ class TestGetModel:
 
     def test_get_model_by_dict_with_init_args(self) -> None:
         """Test get_model by dict with init args."""
-        model = get_model({"class_path": "Padim", "init_args": {"input_size": (100, 100)}})
+        model = get_model({"class_path": "Padim", "init_args": {"backbone": "wide_resnet50_2"}})
         assert isinstance(model, Padim)
-        model = get_model({"class_path": "Patchcore"}, input_size=(100, 100))
+        model = get_model({"class_path": "Patchcore"}, backbone="wide_resnet50_2")
         assert isinstance(model, Patchcore)
 
     def test_get_model_by_dict_with_full_class_path(self) -> None:
         """Test get_model by dict with full class path."""
-        model = get_model({"class_path": "anomalib.models.Padim", "init_args": {"input_size": (100, 100)}})
+        model = get_model({"class_path": "anomalib.models.Padim", "init_args": {"backbone": "wide_resnet50_2"}})
         assert isinstance(model, Padim)
 
     def test_get_model_by_namespace(self) -> None:
@@ -61,7 +61,6 @@ class TestGetModel:
             class_path="anomalib.models.Padim",
             init_args=Namespace(
                 layers=["layer1", "layer2", "layer3"],
-                input_size=(256, 256),
                 backbone="resnet18",
                 pre_trained=True,
                 n_features=None,
@@ -75,7 +74,7 @@ class TestGetModel:
         config = OmegaConf.create({"class_path": "Padim"})
         model = get_model(config)
         assert isinstance(model, Padim)
-        config = OmegaConf.create({"class_path": "Padim", "init_args": {"input_size": (100, 100)}})
+        config = OmegaConf.create({"class_path": "Padim", "init_args": {"backbone": "wide_resnet50_2"}})
         model = get_model(config)
         assert isinstance(model, Padim)
 

--- a/tests/unit/utils/callbacks/visualizer_callback/dummy_lightning_model.py
+++ b/tests/unit/utils/callbacks/visualizer_callback/dummy_lightning_model.py
@@ -61,7 +61,3 @@ class DummyModule(AnomalyModule):
     def learning_type(self) -> LearningType:
         """Returns the learning type."""
         return LearningType.ZERO_SHOT
-
-    def configure_transforms(self, image_size: tuple[int, int] | None) -> None:
-        """Returns the transform."""
-        del image_size


### PR DESCRIPTION
## 📝 Description

- Adds transform saving and loading to/from checkpoint file, see [here](https://github.com/djdameln/anomalib/blob/torchvision-transforms-dyn-input-size/src/anomalib/models/components/base/anomaly_module.py#L257), [here](https://github.com/djdameln/anomalib/blob/torchvision-transforms-dyn-input-size/src/anomalib/models/components/base/anomaly_module.py#L265) and [here](https://github.com/djdameln/anomalib/blob/torchvision-transforms-dyn-input-size/src/anomalib/engine/engine.py#L303).
- Adds [setup](https://github.com/djdameln/anomalib/blob/torchvision-transforms-dyn-input-size/src/anomalib/models/components/base/anomaly_module.py#L56) and [_setup](https://github.com/djdameln/anomalib/blob/torchvision-transforms-dyn-input-size/src/anomalib/models/image/padim/lightning_model.py#L61) methods for dynamic building of the torch model. This is needed so that we can access trainer and/or datamodule attributes when setting up our torch model. For example: use [dynamic model input size](https://github.com/djdameln/anomalib/blob/torchvision-transforms-dyn-input-size/src/anomalib/models/components/base/anomaly_module.py#L238) based on user-specified or checkpoint-loaded transforms.
- Update the transform getting and setting logic in datamodule, lightning model and engine to facilitate the above changes.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
